### PR TITLE
don't die when no or a https image is found

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,12 +10,12 @@ im     = require('imagemagick')
 function fetch(query,cb){
   var google = 'http://ajax.googleapis.com/ajax/services/search/images?v=1.0&rsz=8&q=' + encodeURI(query)
   req({uri:google}, function (e, resp, body) {
-    result = JSON.parse(body)['responseData']['results'][0];
+    result = JSON.parse(body)['responseData']['results'][0]
     
     if(result)
-      cb(result['unescapedUrl']);
+      cb(result['unescapedUrl'])
     else
-      cb("https://img.skitch.com/20110825-ewsegnrsen2ry6nakd7cw2ed1m.png");
+      cb("https://img.skitch.com/20110825-ewsegnrsen2ry6nakd7cw2ed1m.png")
   });
 }
 
@@ -26,9 +26,9 @@ function download(match, output, addText){
       , path = uri.pathname
     
     if(uri.protocol == "https:")
-      var r = https;
+      var r = https
     else 
-      var r = http;
+      var r = http
       
     request = r.get({host: host, path: path}, function(res){
       res.setEncoding('binary')

--- a/index.js
+++ b/index.js
@@ -21,9 +21,6 @@ function fetch(query,cb){
 
 function download(match, output, addText){
   fetch(match, function(file){
-    if(!match) {
-      
-    }
     var uri = url.parse(file)
     var host = uri.hostname
       , path = uri.pathname


### PR DESCRIPTION
currently https image urls are not supported and node dies when we try to download through https. 
I've quickly added a check for https and it now uses the https module for those urls.
Also there was an error when no image is found at all. in this case I'm now just using a fixed default image (d'oh). 
