### PR TITLE
support for utf8 characters

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,7 +11,7 @@ function fetch(query,cb){
   var google = 'http://ajax.googleapis.com/ajax/services/search/images?v=1.0&rsz=8&q=' + encodeURI(query)
   req({uri:google}, function (e, resp, body) {
     result = JSON.parse(body)['responseData']['results'][0]
-    
+
     if(result)
       cb(result['unescapedUrl'])
     else
@@ -24,12 +24,12 @@ function download(match, output, addText){
     var uri = url.parse(file)
     var host = uri.hostname
       , path = uri.pathname
-    
+
     if(uri.protocol == "https:")
       var r = https
-    else 
+    else
       var r = http
-      
+
     request = r.get({host: host, path: path}, function(res){
       res.setEncoding('binary')
       var img = ''

--- a/index.js
+++ b/index.js
@@ -50,7 +50,7 @@ function download(match, output, addText){
 
 server.get("/", function(request, response){
   response.simpleHtml(200, 'fuck yeah / by <a href="http://twitter.com/holman">@holman</a>.'+
-    '<p>api: use <b>fuckyeah.herokuapp.com/[your-query]</b> and shit.</p>'
+    '<p>api: use <b>fuckyeah.herokuapp.com/fuck-yeah?q=[your-query]</b> and shit.</p>'
   );
 })
 
@@ -58,9 +58,10 @@ server.get("/favicon.ico", function(request, response){
   return ""
 })
 
-server.get(new RegExp("^/(.*)$"), function(request, response, match) {
+server.get("/fuck-yeah", function(request, response) {
+  var urlObj = url.parse(request.url, true);
   var msg   = ""
-    , match = escape(match)
+    , match = escape(urlObj.query.q)
     , chars = match.length
 
   if(chars < 7)

--- a/index.js
+++ b/index.js
@@ -61,7 +61,7 @@ server.get("/favicon.ico", function(request, response){
 server.get("/fuck-yeah", function(request, response) {
   var urlObj = url.parse(request.url, true);
   var msg   = ""
-    , match = escape(urlObj.query.q)
+    , match = urlObj.query.q
     , chars = match.length
 
   if(chars < 7)


### PR DESCRIPTION
Currently no UTF8 characters are not supported.
I've changed to use a normal GET parameter which solves this problem.

But that means this changes the API, currently to: /fuck-yeah?q=[your-query]

I haven't found a solution how to fix this in node-router. What do you think?
