### PR TITLE
Allow .jpg at the end of the URL so Campfire/Propane knows it's an image

### DIFF
--- a/index.js
+++ b/index.js
@@ -58,7 +58,7 @@ server.get("/favicon.ico", function(request, response){
   return ""
 })
 
-server.get(new RegExp("^/(.*)$"), function(request, response, match) {
+server.get(new RegExp("^/(.*)(?:.jpg)?$"), function(request, response, match) {
   var msg   = ""
     , match = escape(match)
     , chars = match.length


### PR DESCRIPTION
Linking to a fuckyeah URL and not having the image auto-expand is really harshing our mellow at work.
