### PR TITLE
Allow adding a .jpg file extension so Campfire recognizes URLs as images (redux)

### DIFF
--- a/index.js
+++ b/index.js
@@ -58,7 +58,7 @@ server.get("/favicon.ico", function(request, response){
   return ""
 })
 
-server.get(new RegExp("^/(.*)(?:.jpg)?$"), function(request, response, match) {
+server.get(new RegExp("^/(.*?)(?:.jpg)?$"), function(request, response, match) {
   var msg   = ""
     , match = escape(match)
     , chars = match.length


### PR DESCRIPTION
Commit ebadeff1debe2e1c2a19eff15521cd753b95c559 doesn't do the trick because the greediness of the `.*` eats the extension.

c.f.:
- http://fuckyeah.herokuapp.com/regex.jpg
- http://fuckyeahfileextensions.herokuapp.com/regex.jpg (running 15e87ecc8c754fd22b6f5e73dc54f6fd9c8e412d)
